### PR TITLE
[ARCH-282] fixing the dynamic decorator priority which was accidental…

### DIFF
--- a/dcm4chee-arc-conf/src/main/config/configuration/dcm4chee-arc/dynamic-decorators.json
+++ b/dcm4chee-arc-conf/src/main/config/configuration/dcm4chee-arc/dynamic-decorators.json
@@ -1,27 +1,39 @@
 {
   "dynamicDecorators" : [ {
-      "decoratorClassName" : "org.dcm4chee.archive.compress.impl.StoreServiceCompressDecorator"
+      "decoratorClassName" : "org.dcm4chee.archive.compress.impl.StoreServiceCompressDecorator",
+      "priority" : 12.0
   }, {
-      "decoratorClassName" : "org.dcm4chee.archive.timezone.StoreServiceTimeZoneDecorator"
+      "decoratorClassName" : "org.dcm4chee.archive.timezone.StoreServiceTimeZoneDecorator",
+      "priority" : 11.0
   }, {
-      "decoratorClassName" : "org.dcm4chee.archive.iocm.impl.StoreServiceIOCMDecorator"
+      "decoratorClassName" : "org.dcm4chee.archive.iocm.impl.StoreServiceIOCMDecorator",
+      "priority" : 10.0
   }, {
-      "decoratorClassName" : "org.dcm4chee.archive.mima.impl.StoreServiceMIMADecorator"
+      "decoratorClassName" : "org.dcm4chee.archive.mima.impl.StoreServiceMIMADecorator",
+      "priority" : 9.0
   }, {
-      "decoratorClassName" : "org.dcm4chee.archive.mpps.impl.StoreServiceMPPSDecorator"
+      "decoratorClassName" : "org.dcm4chee.archive.mpps.impl.StoreServiceMPPSDecorator",
+      "priority" : 8.0
   }, {
-      "decoratorClassName" : "org.dcm4chee.archive.mima.impl.MPPSServiceMIMADecorator"
+      "decoratorClassName" : "org.dcm4chee.archive.mima.impl.MPPSServiceMIMADecorator",
+      "priority" : 7.0
   }, {
-      "decoratorClassName" : "org.dcm4chee.archive.mima.impl.RetrieveServiceMIMADecorator"
+      "decoratorClassName" : "org.dcm4chee.archive.mima.impl.RetrieveServiceMIMADecorator",
+      "priority" : 6.0
   }, {
-      "decoratorClassName" : "org.dcm4chee.archive.timezone.StoreSCUServiceTimeZoneDecorator"
+      "decoratorClassName" : "org.dcm4chee.archive.timezone.StoreSCUServiceTimeZoneDecorator",
+      "priority" : 5.0
   }, {
-      "decoratorClassName" : "org.dcm4chee.archive.qc.impl.StoreSCUServiceQCDecorator"
+      "decoratorClassName" : "org.dcm4chee.archive.qc.impl.StoreSCUServiceQCDecorator",
+      "priority" : 4.0
   }, {
-      "decoratorClassName" : "org.dcm4chee.archive.mima.impl.StoreSCUServiceMIMADecorator"
+      "decoratorClassName" : "org.dcm4chee.archive.mima.impl.StoreSCUServiceMIMADecorator",
+      "priority" : 3.0
   }, {
-      "decoratorClassName" : "org.dcm4chee.archive.timezone.QueryServiceTimeZoneDecorator"
+      "decoratorClassName" : "org.dcm4chee.archive.timezone.QueryServiceTimeZoneDecorator",
+      "priority" : 2.0
   }, {
-      "decoratorClassName" : "org.dcm4chee.archive.mima.impl.QueryServiceMIMADecorator"
+      "decoratorClassName" : "org.dcm4chee.archive.mima.impl.QueryServiceMIMADecorator",
+      "priority" : 1.0
   }  ]
 }


### PR DESCRIPTION
Part of a commit which will get pushed soon which gets rid of the priorities was accidentally included in the previous commit. This is adding the priorities back in the configuration as it is still needed by the current implementation.