### PR TITLE
JSON output : not returning empty string but empty json array instead

### DIFF
--- a/dcm4chee-arc-qido/src/main/java/org/dcm4chee/archive/qido/QidoRS.java
+++ b/dcm4chee-arc-qido/src/main/java/org/dcm4chee/archive/qido/QidoRS.java
@@ -372,8 +372,6 @@ public class QidoRS {
                 query.orderBy(orderSpecifiers);
     
             query.executeQuery();
-            if (!query.hasMoreMatches())
-                return Response.ok().build();
     
             return Response.status(status).entity(
                     output.entity(this, query, qrlevel)).build();
@@ -622,7 +620,7 @@ public class QidoRS {
                 MediaTypes.APPLICATION_DICOM_XML_TYPE);
         }
         LOG.info("{}: {} Matches", method, count);
-        return output;
+        return count > 0 ? output : null;
     }
 
     private Object writeJSON(Query query, QueryRetrieveLevel qrlevel) {


### PR DESCRIPTION
On QidoRS when there is no match for a request a empty body is returned which is a problem when client expect a JSON result.
An empty string is invalid JSON and breaks on most system, returning an empty array instead '[]' is correct JSON and is less error prone.

From json.org :

```
JSON is built on two structures:

- A collection of name/value pairs. In various languages, this is realized as an object, record, struct, dictionary, hash table, keyed list, or associative array.
- An ordered list of values. In most languages, this is realized as an array, vector, list, or sequence.
```

So a json message can't be just a string (empty or not) it can only be an object `{...}` or array `[...]` 
( some system allows `null`as well).

Example of system rejecting empty string as JSON : 
- Javascript function `JSON.parse()` consider an empty string as invalid JSON and throws error
- Java JsonParser (glassfish implementation) also throws an exception with the message :  
  `Expected tokens are: [CURLYOPEN, SQUAREOPEN]`  
  _(Didn't test myself but qido-client is also most likely affected by this)_

Now even if some implementation accept empty string as valid JSON it's safer to return an empty array.  

**About code change** : 

For XML output I kept the return of empty string by returning a `null` entity when no match are found (`javax.ws.rs.core.Response.ResponseBuilder.entity(Object)`accepts null as argument). 
